### PR TITLE
Hide QM db.php install prompt

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -19,6 +19,8 @@ function on_plugins_loaded() {
 	$config = get_config()['modules']['dev-tools'];
 
 	if ( $config['query-monitor'] ) {
+		// Hide the db.php dropin installation warning and prompt.
+		add_filter( 'qm/show_extended_query_prompt', '__return_false' );
 		require_once ROOT_DIR . '/vendor/johnbillion/query-monitor/query-monitor.php';
 	}
 }


### PR DESCRIPTION
Right now we don't have a good way to place the `db.php` dropin from Query Monitor into the right location, not least because we also have our own (ludicrous db).

This hides the prompt and warning for now.

Fixes #6 